### PR TITLE
Give our symbol template a class

### DIFF
--- a/sym-treemap-template.html
+++ b/sym-treemap-template.html
@@ -1,3 +1,3 @@
-﻿<div id="treemap">
+﻿<div class="exele-treemap-symbol">
     <svg id="treemap" width="960" height="570"></svg>
 </div>


### PR DESCRIPTION
We don't want to have two of the same ids on a single HTML page. We'll start by adding a class to our template so we can style across all our symbols in the future.