### PR TITLE
Import template into local dev

### DIFF
--- a/app.js
+++ b/app.js
@@ -363,7 +363,7 @@ var eventsModule = function (flinks) {
 
 // creates an internal element object that the module uses
 $('#elementPath').click(function () {
-    eventsModule.Update(_WebAPIServer, elementPath);
+    eventsModule.Update(_WebAPIServer, elementPath, "*-1mo", "*");
 });
 
 

--- a/app.js
+++ b/app.js
@@ -1,12 +1,3 @@
-//need to get unique templates, need to get attributes of template, need to calculate duration
-
-//next need to return the templates, return two attributes and more
-
-var _WebAPIServer = "https://dan-af-dev/piwebapi";
-var afServer = "dan-af-dev"
-var afDatabase = "Mineral Processing";
-var databaseRootURLComplete;
-var elementPath = '\\\\DAN-AF-DEV\\Mineral Processing\\Toll Ore Delivery\\T-101'
 
 var eventsModule = function (flinks) {
     let templates = [];
@@ -180,7 +171,7 @@ var eventsModule = function (flinks) {
     }
 
     // give a templateName, obtains the attributes.
-    function GetTemplateAttributes(templateName) {
+    function GetTemplateAttributes(apiServer, templateName) {
         if (efDataHolder[templateName] === undefined) {
             alert("template not found");
             return;
@@ -198,14 +189,14 @@ var eventsModule = function (flinks) {
                         // console.log(attriubte);
                     })
                 }
-                GetAttributesValues("Net Wet Weight (Mine)", templateName);
+                GetAttributesValues(apiServer, "Net Wet Weight (Mine)", templateName);
             })
         .catch(error=>console.log(error));
     }
     //get a singleEf 
-    function GetSingleEFAttributes(id) {
+    function GetSingleEFAttributes(apiServer, id) {
 
-        let efURL = _WebAPIServer + "streamsets/" + id + "/value";
+        let efURL = apiServer + "streamsets/" + id + "/value";
 
         makeDataCall(efURL, "GET", null, null, null)
         .then(results=> {
@@ -224,7 +215,7 @@ var eventsModule = function (flinks) {
     }
 
     // get the attribute values for each EF given an attributeName and template
-    function GetAttributesValues(attributeName, templateName) {
+    function GetAttributesValues(apiServer, attributeName, templateName) {
         var templateUsed = efDataHolder[templateName];
         //we can make sure the attribute is found on the template...example check
         // var found = templateUsed.attributesTemplates.find(att=>att.Name.toUpperCase() === attributeName.toUpperCase());
@@ -233,13 +224,13 @@ var eventsModule = function (flinks) {
         templateUsed.frames.forEach(EF => {
             let attributeURL;
 
-            attributeURL = encodeURI(_WebAPIServer + "streamsets/" + EF.id + "/value?nameFilter=" + attributeName + "&selectedFields=Items.Value.Value");
+            attributeURL = encodeURI(apiServer + "streamsets/" + EF.id + "/value?nameFilter=" + attributeName + "&selectedFields=Items.Value.Value");
             bulkQuery[EF.id] = {
                 "Method": "GET",
                 "Resource": attributeURL
             };
         });
-        makeDataCall(_WebAPIServer + "batch", "POST", JSON.stringify(bulkQuery), null, null)
+        makeDataCall(apiServer + "batch", "POST", JSON.stringify(bulkQuery), null, null)
         .then(results=>ProcessAttributeResults(results, templateName, attributeName))
         .catch(error=> console.log(error));
     }
@@ -320,7 +311,7 @@ var eventsModule = function (flinks) {
             GetEventFramesByElementID(myel.framesLink, '*-7d', '*', successPromise, errorPromise);
         },
         // gets all of the EF attributes givena  template, need to extended to use attribute name
-        GetEFAttributesValuesFromTemplate: (templateName) =>GetTemplateAttributes(templateName),
+        GetEFAttributesValuesFromTemplate: (apiServer, templateName) =>GetTemplateAttributes(apiServer, templateName),
         // Creates an element object provided a path
         Update: (APIServer, elementPath, startTime, endTime) => {
             //let elementPath = '\\\\PISRV01\\Mineral Processing\\Toll Ore Delivery\\T-101'
@@ -360,17 +351,6 @@ var eventsModule = function (flinks) {
         }
     }
 }();
-
-// creates an internal element object that the module uses
-$('#elementPath').click(function () {
-    eventsModule.Update(_WebAPIServer, elementPath, "*-1mo", "*");
-});
-
-
-$('#buildTreemap').click(() => {
-    var $treemapEl = $('svg#treemap');
-    eventsModule.BuildTreemap($treemapEl);
-});
 
 var makeDataCall = function (url, type, data, successCallBack, errorCallBack) {
     return $.ajax({

--- a/local-dev.html
+++ b/local-dev.html
@@ -2,6 +2,7 @@
 <head>
     <script src="/libraries/jquery-3.1.1.min.js"></script>
     <script src="/libraries/d3.min.js"></script>
+    <link rel="stylesheet" type="text/css" href="treemap.css">
     <title>EF page</title>
     <meta charset="utf-8" />
     <style>
@@ -12,16 +13,13 @@
 </head>
 <body>
     <p>
-        <button type="button" id="loadAFconfig">Load af database + server</button>
-        <button type="button" id="elementPath">Load af database + server</button>
-        <button type="button" id="getEFs">get EFs off element</button>
-        <button type="button" id="getTemplateAttributes">get attributes</button>
-        <button type="button" id="buildTreemap">Build treemap</button>
+        <button type="button" id="btnUpdate">Update</button>
     </p>
 
     <!-- THE TREEMAP -->
     <svg id="treemap" width="960" height="570"></svg>
 
+    <script src="local-dev.js"></script>
     <script src="app.js"></script>
 </body>
 </html>

--- a/local-dev.html
+++ b/local-dev.html
@@ -16,8 +16,7 @@
         <button type="button" id="btnUpdate">Update</button>
     </p>
 
-    <!-- THE TREEMAP -->
-    <svg id="treemap" width="960" height="570"></svg>
+    <link rel="import" href="/sym-treemap-template.html">
 
     <script src="local-dev.js"></script>
     <script src="app.js"></script>

--- a/local-dev.html
+++ b/local-dev.html
@@ -5,6 +5,8 @@
     <link rel="stylesheet" type="text/css" href="treemap.css">
     <title>EF page</title>
     <meta charset="utf-8" />
+    <script src="local-dev.js"></script>
+    <script src="app.js"></script>
     <style>
         svg {
             font: 10px sans-serif;
@@ -12,13 +14,16 @@
     </style>
 </head>
 <body>
-    <p>
-        <button type="button" id="btnUpdate">Update</button>
-    </p>
+    <form>
+        <button type="button"
+                id="btnUpdate">
+            Update
+        </button>
+    </form>
 
-    <link rel="import" href="/sym-treemap-template.html">
-
-    <script src="local-dev.js"></script>
-    <script src="app.js"></script>
+    <link rel="import"
+          href="/sym-treemap-template.html"
+          onload="handleLoad(event)"
+          onerror="handleError(event)">
 </body>
 </html>

--- a/local-dev.js
+++ b/local-dev.js
@@ -1,0 +1,10 @@
+﻿
+var apiServer = "https://dan-af-dev/piwebapi";
+var elementPath = '\\\\DAN-AF-DEV\\Mineral Processing\\Toll Ore Delivery\\T-101';
+var tStart = "*-1mo";
+var tEnd = "*";
+
+// creates an internal element object that the module uses
+$('#btnUpdate').click(function () {
+    eventsModule.Update(apiServer, elementPath, tStart, tEnd);
+});

--- a/local-dev.js
+++ b/local-dev.js
@@ -1,10 +1,17 @@
-﻿
-var apiServer = "https://dan-af-dev/piwebapi";
+﻿var apiServer = "https://dan-af-dev/piwebapi";
 var elementPath = '\\\\DAN-AF-DEV\\Mineral Processing\\Toll Ore Delivery\\T-101';
 var tStart = "*-1mo";
 var tEnd = "*";
 
-// creates an internal element object that the module uses
-$('#btnUpdate').click(function () {
-    eventsModule.Update(apiServer, elementPath, tStart, tEnd);
-});
+function handleLoad(e) {
+    var importedContent = document.querySelector('link[rel="import"]').import;
+
+    // creates an internal element object that the module uses
+    $('#btnUpdate').click(function () {
+        eventsModule.Update(apiServer, elementPath, tStart, tEnd);
+    }.bind(importedContent));
+}
+
+function handleError(e) {
+    console.log('Error loading import: ' + e.target.href);
+}


### PR DESCRIPTION
This imports the symbol's template into our local dev HTML file to get us using HTML that is closer to what's in production, locally.

This is posted as an example of how to implement https://github.com/jrsconfitto/VisVirtualHackathon/issues/14#issuecomment-281996874. i found that we can use "HTML Imports" from [this very helpful article on HTML Imports from HTML5 Rocks](https://www.html5rocks.com/en/tutorials/webcomponents/imports/).