### PR TITLE
Attribute none

### DIFF
--- a/app.js
+++ b/app.js
@@ -152,7 +152,8 @@ var eventsModule = function () {
     }
     // used to return all of the EF templates used as array
     function GetTemplates() {
-        templates = ["None"];
+      var  templates = [];
+         //["None"];
         for (var t in efDataHolder) {
             templates.push(t);
         }
@@ -160,13 +161,13 @@ var eventsModule = function () {
     }
     // use to return the attributes as array given a template
     function GetEFAttributesFromTemplate(templateName) {
-        var attResults = ["None"];
+        
         var attributes = [];
         if (efDataHolder[templateName]) {
             attributes = efDataHolder[templateName].attributeNames;
         }
 
-        return ["None"].concat(attributes);
+        return attributes;
     }
 
 

--- a/local-dev.js
+++ b/local-dev.js
@@ -52,6 +52,8 @@ $(document).on('efClick', function (ev, data) {
 })
 
 function fillSelect($select, items) {
+
+    items.unshift('None');
     // Initialize the selected template and attributes
     var options = items.map(function(t) {
         return '<option value="' + t + '">' + t + '</option>';

--- a/sym-treemap.js
+++ b/sym-treemap.js
@@ -21,6 +21,8 @@
          return efTemplates;
         };
 
+        var cachedA=[];
+
         // method used to get the current attributes from the template
         runtimeData.obtainAttributes = function () {
             var efAttributes= eventsModule.GetEFAttributesFromTemplate(mytemplate);

--- a/sym-treemap.js
+++ b/sym-treemap.js
@@ -14,20 +14,19 @@
         var mytemplate = "";
         // put runtimeData in scope
         var runtimeData = scope.runtimeData;
+        
         // method use to get the current EF
         runtimeData.obtainTemplates = function () {
             var efTemplates = eventsModule.GetEFTemplates()
-         efTemplates.unshift('None');
-         return efTemplates;
+            efTemplates.unshift('None');
+            return efTemplates;
         };
-
-        var cachedA=[];
 
         // method used to get the current attributes from the template
         runtimeData.obtainAttributes = function () {
-            var efAttributes= eventsModule.GetEFAttributesFromTemplate(mytemplate);
-            efAttributes.unshift('None');
-            return efAttributes;
+            var efAttributes= eventsModule.GetEFAttributesFromTemplate(mytemplate);          
+               // return like this so angular does not loop forever
+                return ['None'].concat(efAttributes);                    
         };
 
 

--- a/sym-treemap.js
+++ b/sym-treemap.js
@@ -16,12 +16,16 @@
         var runtimeData = scope.runtimeData;
         // method use to get the current EF
         runtimeData.obtainTemplates = function () {
-            return eventsModule.GetEFTemplates()
+            var efTemplates = eventsModule.GetEFTemplates()
+         efTemplates.unshift('None');
+         return efTemplates;
         };
 
         // method used to get the current attributes from the template
         runtimeData.obtainAttributes = function () {
-            return eventsModule.GetEFAttributesFromTemplate(mytemplate);
+            var efAttributes= eventsModule.GetEFAttributesFromTemplate(mytemplate);
+            efAttributes.unshift('None');
+            return efAttributes;
         };
 
 


### PR DESCRIPTION
Moved selecting no ("None") for attribute and template out of EF module as this is UI driven.  Updated both local dev and app.js.  Used concat with array to get around angular looping when it compares object for changes.

Current rule.  When a user selects no template, all EFs are displayed.  When no attribute is selected, the duration is used by default. 
