### PR TITLE
compute total duration when creating hierarchy

### DIFF
--- a/app.js
+++ b/app.js
@@ -359,7 +359,6 @@ var eventsModule = function () {
         var efDataRoot = {
             name: '',
             children: [],
-            totalDuration: 0
         };
 
         // Converts the passed EFs into data objects for use in the treemap
@@ -401,20 +400,11 @@ var eventsModule = function () {
                 });
         }
 
-        var sumFrameDuration = function (efFrames) {
-            var frameSum = 0;
-            for (var i = 0; i < efFrames.length; i++) {
-                frameSum += ((efFrames[i].ef.EndTime - efFrames[i].ef.StartTime) / 1000 / 60);
-            }
-            return frameSum;
-        }
-
         if (_template && _template !== 'None' && efDataHolder[_template]) {
 
             var efs = efDataHolder[_template];
             efDataRoot.name = _template;
             efDataRoot.children = getChildrenFromFrames(efs.frames);
-            efDataRoot.totalDuration += sumFrameDuration(efs.frames);
 
         } else {
 
@@ -429,11 +419,8 @@ var eventsModule = function () {
                     name: efName,
                     children: getChildrenFromFrames(efs.frames)
                 });
-
-                efDataRoot.totalDuration += sumFrameDuration(efs.frames);
             }
         }
-
 
         // Might be useful to allow summing by count, in the future.
         function sumByCount(d) {
@@ -444,6 +431,15 @@ var eventsModule = function () {
           .eachBefore(function (d) {
               d.data.id = (d.parent ? d.parent.data.id + '.' : '') + d.data.name + (d.data.ef ? '.' + d.data.ef.webId : '');
               // d.WebId = "1111"
+          })
+          .eachAfter(function(d) {
+              if (d.children) {
+                  d.data.totalDuration = d.children.reduce(function(a, b) {
+                      return a + b.data.duration;
+                  }, 0)
+              } else {
+                  d.data.totalDuration = d.data.durationMinutes;
+              }
           })
           .sum(function (d) {
               // The `sum` determines the size of the cells within the treemap.

--- a/app.js
+++ b/app.js
@@ -433,12 +433,11 @@ var eventsModule = function () {
               // d.WebId = "1111"
           })
           .eachAfter(function(d) {
+              // Give nodes with children `durationMinutes` properties equal to the sum of the durations of their children.
               if (d.children) {
-                  d.data.totalDuration = d.children.reduce(function(a, b) {
-                      return a + b.data.duration;
+                  d.data.durationMinutes = d.children.reduce(function(a, b) {
+                      return a + b.data.durationMinutes;
                   }, 0)
-              } else {
-                  d.data.totalDuration = d.data.durationMinutes;
               }
           })
           .sum(function (d) {
@@ -570,7 +569,7 @@ var eventsModule = function () {
             var root = EFsToHierarchy();
 
             var $totalTimeElement = $('.exele-total-time', symbolElement);
-            $totalTimeElement[0].innerHTML = 'Total event time: ' + root.data.totalDuration.toFixed(2);
+            $totalTimeElement[0].innerHTML = 'Total event time: ' + root.data.durationMinutes.toFixed(2);
 
             // Draw the treemap within the selected element using the data in `root`
             treemapSelection


### PR DESCRIPTION
refactored the total duration to be computed when creating the d3 hierarchy instead of after the fact.

@jrsconfitto I looked at putting logic in the `.eachBefore` but it looks like that will need a similar conditional to test what type of node is being processed and handle children vs. EF objects