### PR TITLE
use durationMinutes to calculate the total duration in minutes.

### DIFF
--- a/app.js
+++ b/app.js
@@ -131,7 +131,7 @@ var eventsModule = function () {
                     .text(function (d) {
                         var title = d.data.name
                             + '\nTemplate: ' + d.data.ef.templateName
-                            + '\nDuration: ' + format(d.value) + ' minutes'
+                            + '\nDuration: ' + format(d.data.durationMinutes) + ' minutes'
                             + '\nStart: ' + d.data.startTime.toLocaleString()
                             + '\nEnd: ' + d.data.endTime.toLocaleString();
 


### PR DESCRIPTION
The duration was being calculated on the data and not the minutes resulting in incorrect tool tip when an EF template was selected.  This resolve the issue.